### PR TITLE
Automatically set SERVER_HOSTNAME to maintain backwards-compatibility

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,20 @@ set -e
 
 export HOSTNAME=$(echo "$VCAP_APPLICATION" | cut -d'[' -f2 | cut -d']' -f1 | tr -d '"')
 
-if [[ $HOSTNAME = *","* ]] && [[ -z "$SERVER_HOSTNAME" ]]; then
+contains_comma()
+{
+  case "$1" in
+    *,*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ -z "$SERVER_HOSTNAME" ] && contains_comma $HOSTNAME; then
   echo "Multiple routes bound to the app but no SERVER_HOSTNAME variable is set."
   exit 1
 fi
 
-if [[ -z "$SERVER_HOSTNAME" ]]; then
+if [ -z "$SERVER_HOSTNAME" ]; then
   export SERVER_HOSTNAME=$HOSTNAME
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,15 @@ set -e
 
 export HOSTNAME=$(echo "$VCAP_APPLICATION" | cut -d'[' -f2 | cut -d']' -f1 | tr -d '"')
 
+if [[ $HOSTNAME = *","* ]] && [[ -z "$SERVER_HOSTNAME" ]]; then
+  echo "Multiple routes bound to the app but no SERVER_HOSTNAME variable is set."
+  exit 1
+fi
+
+if [[ -z "$SERVER_HOSTNAME" ]]; then
+  export SERVER_HOSTNAME=$HOSTNAME
+fi
+
 ${LCSRV_HOME}/bin/license-server.sh configure \
 		--listen 0.0.0.0 \
 		--port 8111 \


### PR DESCRIPTION
If the SERVER_HOSTNAME env variable is not set, the entrypoint will set
the HOSTNAME variable to it, which contains the public URL extracted from
VCAP_APPLICATION. If the SERVER_HOSTNAME variable is empty and the
HOSTNAME variable contains multiple URLs the scriptexits with an error
message as the primary url could not be recognized.